### PR TITLE
docs(example): rename `DatePicker` event handler method example

### DIFF
--- a/docs/examples/date_picker_example.py
+++ b/docs/examples/date_picker_example.py
@@ -7,7 +7,7 @@ class DatePickerApp(App[None]):
     def compose(self) -> ComposeResult:
         yield DatePicker()
 
-    def on_date_picker_date_changed(self, message: DatePicker.Changed) -> None:
+    def on_date_picker_changed(self, message: DatePicker.Changed) -> None:
         message.stop()
         if message.date:
             msg = f"Date changed to {message.date.format_common_iso()}."


### PR DESCRIPTION
As mentioned in (#1) the the method name here is outdated and therefore is not being picked up by a handler.