### PR TITLE
Add greedy parameter to arrange method for Textual compatibility

### DIFF
--- a/src/textual_timepiece/timeline/_timeline_layouts.py
+++ b/src/textual_timepiece/timeline/_timeline_layouts.py
@@ -44,6 +44,7 @@ class AbstractTimelineLayout(Layout, Generic[T]):
         self,
         parent: AbstractTimeline[T],
         entries: list[T],
+        greedy: bool = False,
         size: Size,
     ) -> ArrangeResult:
         if not self.tile:

--- a/src/textual_timepiece/timeline/_timeline_layouts.py
+++ b/src/textual_timepiece/timeline/_timeline_layouts.py
@@ -44,7 +44,7 @@ class AbstractTimelineLayout(Layout, Generic[T]):
         self,
         parent: AbstractTimeline[T],
         entries: list[T],
-        greedy: bool = False,
+        greedy: bool,
         size: Size,
     ) -> ArrangeResult:
         if not self.tile:


### PR DESCRIPTION
I was thrown an error because _abstract_timeline_layout.arrange() recieved an unexpected parameter 'greedy'. Probably from a recent update to Textual. added it in the input parameters as a bool and it solved my issue.