### PR TITLE
ci: add push trigger for CodeQL workflow on main branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
 name: "CodeQL Advanced"
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Deals with a warning in actions:
```bash
Warning: 1 issue was detected with this workflow: Please specify an on.push hook to analyze and see code scanning alerts from the default branch on the Security tab.
```